### PR TITLE
feat: allow including logcat

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Add the Rollbar access token to your capacitor.config.json:
   "plugins": {
     "CapacitorRollbar": {
       "accessToken": "YOUR_ROLLBAR_ACCESS_TOKEN",
-      "environment": "development" // or "production" based on your environment
+      "environment": "development" // or "production" based on your environment,
+      "includeLogcat": false // setting this to true will include the last 100 logcat log messages along with the rollbar report
     }
   }
 }

--- a/android/src/main/java/com/hawk/plugin/rollbar/CapacitorRollbarPlugin.java
+++ b/android/src/main/java/com/hawk/plugin/rollbar/CapacitorRollbarPlugin.java
@@ -20,7 +20,8 @@ public class CapacitorRollbarPlugin extends Plugin {
         // Retrieve the access token from capacitor.config.json
         String accessToken = getConfig().getString("accessToken");
         String environment = getConfig().getString("environment");
-        Rollbar.init(getContext(), accessToken, environment, true);
+        Boolean includeLogCat = getConfig().getBoolean("includeLogcat", false);
+        Rollbar.init(getContext(), accessToken, environment, true, includeLogCat);
         String deviceBuildSerialNo = android.os.Build.SERIAL;
         rollbar = Rollbar.instance();
         rollbar.setPersonData(deviceBuildSerialNo, "", "");


### PR DESCRIPTION
Adds a config option `includeLogcat` to optionally include the last 100 logcat entries prior to this error thrown.